### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,7 +3,7 @@
 class SolrDocument
   include Blacklight::Solr::Document
 
-  DOI_HTTP_PREFIX = 'http://dx.doi.org/'
+  DOI_HTTP_PREFIX = 'https://doi.org/'
 
   # self.unique_key = 'id'
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe SolrDocument do
         {
           id: 'http://sul.stanford.edu/rialto/publications/7fec3f81bdf190e3e04d593c99803293',
           type_ssi: 'Publication',
-          doi_ssim: ['http://dx.doi.org/10.1234/foo-bar']
+          doi_ssim: ['https://doi.org/10.1234/foo-bar']
         }
       end
 
       it 'returns HTML' do
         expect(doi).to eq(
-          '<a href="http://dx.doi.org/10.1234/foo-bar">' \
+          '<a href="https://doi.org/10.1234/foo-bar">' \
             '10.1234/foo-bar' \
           '</a>'
         )
@@ -33,18 +33,18 @@ RSpec.describe SolrDocument do
           id: 'http://sul.stanford.edu/rialto/publications/7fec3f81bdf190e3e04d593c99803293',
           type_ssi: 'Publication',
           doi_ssim: [
-            'http://dx.doi.org/10.1234/foo-bar',
-            'http://dx.doi.org/10.5678/baz-quux'
+            'https://doi.org/10.1234/foo-bar',
+            'https://doi.org/10.5678/baz-quux'
           ]
         }
       end
 
       it 'returns HTML' do
         expect(doi).to eq(
-          '<a href="http://dx.doi.org/10.1234/foo-bar">' \
+          '<a href="https://doi.org/10.1234/foo-bar">' \
             '10.1234/foo-bar' \
             '</a> and ' \
-            '<a href="http://dx.doi.org/10.5678/baz-quux">' \
+            '<a href="https://doi.org/10.5678/baz-quux">' \
             '10.5678/baz-quux' \
             '</a>'
         )


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!