### PR TITLE
Git is not necessary to build the image anymore

### DIFF
--- a/docker/Dockerfile.ruby
+++ b/docker/Dockerfile.ruby
@@ -15,7 +15,6 @@ COPY Gemfile.lock /opt
 
 RUN apk --no-cache add \
   libpq \
-  git \
   tzdata
 
 


### PR DESCRIPTION
Since we are now loading blacklight from rubygems (and not github).