### PR TITLE
Bundle install before building the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,9 @@ jobs:
           version: 18.05.0-ce
       - checkout
       - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+      - run:
           name: Build Image & Register Task
           command: |
             ./bin/build

--- a/bin/build
+++ b/bin/build
@@ -10,6 +10,6 @@
 # echo $IMAGE_NAME
 
 # We explicitly build them individually because we don't use 'depends_on'
-rake assets:precompile
-docker-compose build ruby
-docker-compose build app
+rake assets:precompile \
+&& docker-compose build ruby \
+&& docker-compose build app


### PR DESCRIPTION
Previously, the rake assets:precompile step was failing because bundler had not yet installed rake.