### PR TITLE
Hard commit every minute

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -16,8 +16,7 @@
     </updateLog>
 
     <autoCommit>
-      <maxTime>15000</maxTime>
-      <openSearcher>false</openSearcher>
+      <maxTime>60000</maxTime>
     </autoCommit>
   </updateHandler>
 


### PR DESCRIPTION
Previously we were not opening a searcher, so new documents were not showing in the webapp.

Fixes sul-dlss/rialto-etl#274