### PR TITLE
Add okcomputer to introduce /okcomputer healthcheck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'puma', '~> 3.11'
 gem 'blacklight', '~> 7.0'
 gem 'honeybadger'
 gem 'lograge'
-
+gem 'okcomputer'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '4.0.0.rc.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    okcomputer (1.17.3)
     parallel (1.13.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
@@ -234,6 +235,7 @@ DEPENDENCIES
   json (~> 2.1)
   listen (>= 3.0.5, < 3.2)
   lograge
+  okcomputer
   pg
   puma (~> 3.11)
   rails (~> 5.2.0)


### PR DESCRIPTION
A quick update to include a `/okcomputer` healthcheck path so our ECS healthcheck doesn't timeout
