### PR TITLE
Set database timeout to 2 minutes for long queries

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   min_messages: warning
   pool: <%= Integer(ENV.fetch("DB_POOL", 5)) %>
   reaping_frequency: <%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>
-  timeout: 5000
+  timeout: 120000
   <% unless local %>
   username: <%= ENV.fetch('RDS_USERNAME', 'postgres') %>
   password: <%= ENV.fetch('RDS_PASSWORD', '') %>


### PR DESCRIPTION
Set an extended timeout in the webapp to deal with slow report queries.