### PR TITLE
Update ruby to match docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 3
     docker:
-      - image: circleci/ruby:2.5.3-stretch-node
+      - image: circleci/ruby:2.5.4-stretch-node
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.3'
+ruby '2.5.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ DEPENDENCIES
   webpacker (= 4.0.0.rc.7)
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.5.4p155
 
 BUNDLED WITH
    2.0.1


### PR DESCRIPTION
The alpine image we're using (especially in circle) is now using 2.5.4 and throws an error about 2.5.3