### PR TITLE
add (ruby) code coverage to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,52 +29,43 @@ jobs:
     steps:
     - checkout
 
-    # Upgrade bundler
     - run:
-        name: Install Bundler
+        name: Install/Upgrade Bundler
         command: gem install bundler
-
-    # Which version of bundler?
     - run:
-        name: Which bundler?
+        name: Which version of bundler?
         command: bundle -v
-
-    # Restore bundle cache
     - restore_cache:
         keys:
         - app-bundle-v2-{{ checksum "Gemfile.lock" }}
         - app-bundle-v2-
-
     - run:
         name: Bundle Install
         command: bundle check || bundle install
-
-    # Store bundle cache
     - save_cache:
         key: app-bundle-v2-{{ checksum "Gemfile.lock" }}
         paths:
         - vendor/bundle
 
-    # Only necessary if app uses webpacker or yarn in some other way
     - restore_cache:
         keys:
           - app-yarn-{{ checksum "yarn.lock" }}
           - app-yarn-
-
     - run:
         name: Yarn Install
         command: yarn install --cache-folder ~/.cache/yarn
-
-    # Store yarn / webpacker cache
     - save_cache:
         key: app-yarn-{{ checksum "yarn.lock" }}
         paths:
           - ~/.cache/yarn
 
     - run:
+        name: Check styles using rubocop
+        command: bundle exec rubocop
+
+    - run:
         name: Wait for DB
         command: dockerize -wait tcp://localhost:5432 -timeout 1m
-
     - run:
         name: Database setup
         command: bin/rails db:schema:load --trace
@@ -89,24 +80,20 @@ jobs:
           curl -H 'Content-type: application/json' http://localhost:8983/api/collections/ -d '{create: {name: blacklight-core, config: blacklight-core, numShards: 1}}'
 
     - run:
-        name: Check styles using rubocop
-        command: bundle exec rubocop
-
-    # Run rspec in parallel
-    - run:
-        name: Run rspec in parallel
+        name: Setup Code Climate test-reporter
         command: |
-          bundle exec rspec --profile 10 \
-                            --format RspecJunitFormatter \
-                            --out test_results/rspec.xml \
-                            --format progress \
-                            $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-
-    # Run Javascript Unit tests
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+    - run:
+        name: Run rspec tests
+        command: bundle exec rspec
     - run:
         name: Run javascript unit tests
         command: npm test
-
+    - run:
+        name: upload test coverage report to Code Climate
+        command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
     # Save test results for timing analysis
     - store_test_results:
         path: test_results
@@ -185,10 +172,8 @@ workflows:
 
   test:
     jobs:
-    - test:
-        filters:
-          branches:
-            ignore: master
+    - test
+
   build:
     jobs:
     - build-image:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+## Why was this change made?
+
+
+## Was the documentation (README, wiki, ...) updated?

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-debug.log*
 .yarn-integrity
 
 spec/examples.txt
+
+/coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   gem 'rspec_junit_formatter'
   gem 'rubocop', '~> 0.66.0'
   gem 'rubocop-rspec'
+  gem 'simplecov'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     deprecation (1.0.0)
       activesupport
     diff-lcs (1.3)
+    docile (1.3.2)
     erubi (1.9.0)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
@@ -188,6 +189,11 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -233,10 +239,11 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 0.66.0)
   rubocop-rspec
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   webpacker (~> 4.2)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rialto Webapp
 [![CircleCI](https://circleci.com/gh/sul-dlss/rialto-webapp/tree/master.svg?style=svg)](https://circleci.com/gh/sul-dlss/rialto-webapp/tree/master)
+[![Ruby Test Coverage](https://api.codeclimate.com/v1/badges/4cbc00acb15a14969620/test_coverage)](https://codeclimate.com/github/sul-dlss/rialto-webapp/test_coverage)
+[![Ruby Maintainability](https://api.codeclimate.com/v1/badges/4cbc00acb15a14969620/maintainability)](https://codeclimate.com/github/sul-dlss/rialto-webapp/maintainability)
 [![](https://images.microbadger.com/badges/image/suldlss/rialto-webapp.svg)](https://microbadger.com/images/suldlss/rialto-webapp "Get your own image badge on microbadger.com")
 
 This is the Blacklight frontend for Rialto.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,10 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+
+require 'simplecov'
+SimpleCov.start 'rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
## Why was this change made?

Code coverage is a great tool to indicate some of the code that needs tests (it is an imperfect tool).  Having it be part of the CI build is useful.  So are the badges.

Note that I have another branch in which I am working on getting javascript coverage as well.

Connected to #391

## Was the documentation (README, wiki, ...) updated?

README badges added for codeclimate info.