### PR TITLE
Update the ruby version in docker

### DIFF
--- a/docker/Dockerfile.ruby
+++ b/docker/Dockerfile.ruby
@@ -1,4 +1,4 @@
-FROM ruby:2.6.2-alpine3.9
+FROM ruby:2.7.1-alpine
 
 # Create and set the working directory as /opt
 WORKDIR /opt


### PR DESCRIPTION
## Why was this change made?

Now that tests pass in 2.7.1, setup the docker image to use 2.7.1

## Was the documentation (README, wiki, ...) updated?
